### PR TITLE
Update default status in refund requests fixture

### DIFF
--- a/refund-requests/post.json
+++ b/refund-requests/post.json
@@ -29,7 +29,7 @@
         },
         "attributes": {
           "reason": "Wrong part",
-          "status": "new",
+          "status": "pending",
           "at-fault": "supplier",
           "max-refund-in-cents": "number#max-refund-in-cents"
         },


### PR DESCRIPTION
[Order Status should update correctly through return/refund process](https://www.pivotaltracker.com/story/show/156173530)